### PR TITLE
Fix image URL trimming for non-string cells

### DIFF
--- a/script.js
+++ b/script.js
@@ -733,27 +733,6 @@ function displayData(data, isMultiSheet = false) {
                 }
 
                 if (!isImage) {
-                let isImage = false;
-                if (header === 'Image' && value) {
-                    const cleanValue = String(value).trim();
-                    if (cleanValue.startsWith('http')) {
-                        const img = document.createElement('img');
-                        img.src = cleanValue;
-                        img.alt = row['Name'] || 'Image';
-                        img.className = 'item-image';
-                        img.loading = 'lazy';
-                        td.appendChild(img);
-                        td.className = 'image-cell';
-                        isImage = true;
-                    }
-                }
-
-                if (!isImage) {
-                    img.className = 'item-image';
-                    img.loading = 'lazy';
-                    td.appendChild(img);
-                    td.className = 'image-cell';
-                } else {
                     td.textContent = value;
                     td.title = 'Click to expand';
 
@@ -776,16 +755,22 @@ function displayData(data, isMultiSheet = false) {
                 const value = row[header] || '';
 
                 // Special handling for Image column
-                const cleanValue = value ? value.trim() : '';
-                if (header === 'Image' && cleanValue && cleanValue.startsWith('http')) {
-                    const img = document.createElement('img');
-                    img.src = cleanValue;
-                    img.alt = row['Name'] || 'Image';
-                    img.className = 'item-image';
-                    img.loading = 'lazy';
-                    td.appendChild(img);
-                    td.className = 'image-cell';
-                } else {
+                let isImage = false;
+                if (header === 'Image' && value) {
+                    const cleanValue = String(value).trim();
+                    if (cleanValue.startsWith('http')) {
+                        const img = document.createElement('img');
+                        img.src = cleanValue;
+                        img.alt = row['Name'] || 'Image';
+                        img.className = 'item-image';
+                        img.loading = 'lazy';
+                        td.appendChild(img);
+                        td.className = 'image-cell';
+                        isImage = true;
+                    }
+                }
+
+                if (!isImage) {
                     td.textContent = value;
                     td.title = 'Click to expand';
 


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` thrown when non-string cell values have `trim()` called unconditionally.
- Ensure image URLs with leading or trailing whitespace still load by trimming only when handling the `Image` column.
- Remove duplicated image-rendering logic in the multi-sheet rendering path to simplify behavior.

### Description
- Update `script.js` to coerce values with `String(value).trim()` and only perform the `startsWith('http')` check inside the `Image` column branch.
- Remove the duplicated image-rendering block in the multi-sheet code path and ensure non-image cells are rendered without invoking `trim()`.
- Preserve existing lazy-loading (`loading = 'lazy'`) and alt text behavior for images.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d2d00de4833290aab1e34abc6b29)