### PR TITLE
Fix image formula URL parsing for sheet display

### DIFF
--- a/script.js
+++ b/script.js
@@ -441,9 +441,14 @@ function resolveImageUrl(value) {
         return trimmed;
     }
 
-    const match = trimmed.match(/^=IMAGE\(\s*(['"])(.*?)\1/i);
-    if (match && match[2]) {
-        return match[2].trim();
+    const formulaMatch = trimmed.match(/IMAGE\(\s*["']?([^"')]+)["']?\s*\)/i);
+    if (formulaMatch && formulaMatch[1]) {
+        return formulaMatch[1].trim();
+    }
+
+    const urlMatch = trimmed.match(/https?:\/\/[^\s"'<>]+/i);
+    if (urlMatch && urlMatch[0]) {
+        return urlMatch[0].trim();
     }
 
     return '';


### PR DESCRIPTION
### Motivation
- Sheet image cells containing `=IMAGE("...")` formulas or HTML-wrapped content were being shown as raw text instead of resolving to the underlying image URL.
- The application needs to extract a usable URL from a variety of formats returned by Google Sheets when `valueRenderOption=FORMULA` is used.

### Description
- Updated `resolveImageUrl` in `script.js` to use a more flexible regex that extracts the URL from `IMAGE(...)` formulas (handles optional quotes and surrounding text).
- Added a fallback regex to extract any `http(s)://` URL found inside the image cell when formula parsing fails.
- Preserved the existing behavior of returning a trimmed `http` value when the cell already starts with a direct URL.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950dfa7145083329230bc545d11b6b4)