### PR TITLE
Fix sheet name parsing and multi-sheet detection in search results

### DIFF
--- a/script.js
+++ b/script.js
@@ -953,7 +953,11 @@ async function fetchSheetsBatch(sheetNames) {
     const ranges = data.valueRanges || [];
 
     for (const range of ranges) {
-        const sheetName = range.range.split('!')[0];
+        // The Sheets API wraps names containing spaces or special characters in
+        // single quotes (e.g. "'Tools/Goods'!A1:ZZ500"). Strip those quotes so
+        // the key in allSheetsData matches the raw sheet name used everywhere else.
+        const rawName = range.range.split('!')[0];
+        const sheetName = rawName.replace(/^'(.*)'$/, '$1');
         const rows = range.values || [];
         const headers = rows[0] || [];
         const dataRows = [];
@@ -1462,9 +1466,12 @@ async function applyFilters() {
                 });
             }
 
-            // Check if results come from multiple sheets
+            // Check if results come from multiple sheets.
+            // Always treat global-search results as multi-sheet so that
+            // setupHeadersForDisplay enters its isMultiSheet branch and
+            // sets headers — even when only one sheet has matches.
             const uniqueSheets = new Set(combinedData.map(row => row._sheet));
-            isMultiSheet = uniqueSheets.size > 1;
+            isMultiSheet = isGlobalSearch || uniqueSheets.size > 1;
 
             // Sort by sheet name to group results together
             if (isMultiSheet) {


### PR DESCRIPTION
## Summary
This PR fixes two related issues in the search and filtering logic:
1. Sheet names containing spaces or special characters are now correctly parsed from the Sheets API response
2. Global search results are now always treated as multi-sheet to ensure headers are properly displayed

## Key Changes
- **Sheet name parsing**: The Sheets API wraps sheet names containing spaces or special characters in single quotes (e.g., `'Tools/Goods'!A1:ZZ500`). Added logic to strip these quotes so the sheet name key matches the raw sheet name used elsewhere in the codebase.
- **Multi-sheet detection**: Modified the `isMultiSheet` flag to treat global search results as multi-sheet regardless of the actual number of sheets with matches. This ensures the `setupHeadersForDisplay` function enters its multi-sheet branch and properly sets headers even when only one sheet has search results.

## Implementation Details
- The sheet name is extracted from the range string, then cleaned with a regex replacement that removes surrounding single quotes if present
- The multi-sheet flag now uses: `isMultiSheet = isGlobalSearch || uniqueSheets.size > 1`
- Added clarifying comments explaining the special handling for global search results

https://claude.ai/code/session_01CyGqkCX32FrnxMKQDMj2Zt